### PR TITLE
style: x버튼 위치 수정

### DIFF
--- a/src/components/ProductCard/styled.js
+++ b/src/components/ProductCard/styled.js
@@ -28,6 +28,7 @@ const flexStyle = css`
 `;
 
 export const Container = styled.div`
+    position: relative;
     display: flex;
     align-items: center;
     gap: 12px;


### PR DESCRIPTION
### 무엇을 위한 PR인가요?

선물 목록이 리스트로 보여질때 x 버튼이 ios에서 container를 넘어가 동떨어져 보이는 현상 수정